### PR TITLE
TEL-4189 Updates security-git-hooks pre-commit hook

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/hmrc/telemetry-docker-resources",
-  "commit": "04a7fdeae17f888fa5ae9405d6c03c9cce16acd1",
+  "commit": "23cadf2247392cf3b02be0becc850ebb6c1f7f07",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -10,7 +10,7 @@
       "docker_build_options_default": "",
       "docker_image_name": "telemetry-carbon-relay-ng",
       "docker_image_name_formatted": "telemetry-carbon-relay-ng",
-      "docker_include_default_build": true,
+      "docker_include_default_build": "True",
       "repository_name": "telemetry-carbon-relay-ng",
       "additional_tool_versions": {},
       "docker_build_options_additional": {},

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
         name: Fix missing end-of-file line returns
         exclude: repository.yaml|tests/unit/test-data/
   - repo: https://github.com/hmrc/security-git-hooks
-    rev: release/1.9.0
+    rev: release/1.10.0
     hooks:
       - id: secrets_filecontent
         name: Checking staged files for sensitive content

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Test 2: Blocking Scenario
   3. Navigate back to the performance page and hit refresh and you should see Metric.direction_is_blocklist: 1
 
 Test 3: Successful Scenario
-  1. Run the following command to list all running containers and copy the ID of the ClickHouse container: ```docker ps``` 
+  1. Run the following command to list all running containers and copy the ID of the ClickHouse container: ```docker ps```
   2. Enter interactive mode for the ClickHouse container: ```docker exec -it <Container_ID> clickhouse-client```
   3. In the ClickHouse interactive mode, run the following SQL query to check if the ClickHouse container is working:``` SELECT * FROM graphite.graphite ORDER BY Date DESC  LIMIT 5 ```
   4. Ensure that you see relevant data.
@@ -51,9 +51,3 @@ Test 3: Successful Scenario
 ```docker-compose down```
 
 ### Testing complete!!!
-
-
-
-
-
-


### PR DESCRIPTION
What we have done
--

Updated the hook to a version that pulls in setuptools under python 3.12, to fix "No module named 'pkg_resources" errors.

References
--

1. Fix described here https://github.com/hmrc/security-git-hooks/pull/24
2. https://jira.tools.tax.service.gov.uk/browse/TEL-4189

Evidence of work
--

1. Run 'pre-commit  run --all-files --verbose secrets_filecontent'
2. **Assert that** it passes

Collaborators
--

Co-authored by: Stephen Palfreyman <18111914+sjpalf@users.noreply.github.com>
