### PR TITLE
TEL-4120 Add port 2103 to the environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,8 @@ services:
       - "2003:2003"
       - "8081:8081"
     environment:
-      - GRAFANA_NET_ADDR=carbon-clickhouse
-      - GRAFANA_NET_API_KEY=carbon-clickhouse
+      - GRAFANA_NET_ADDR=carbon-clickhouse:2103
+      - GRAFANA_NET_API_KEY=carbon-clickhouse:2103
 
   carbon-clickhouse:
     image: lomik/carbon-clickhouse:latest

--- a/templates/carbon-relay-ng.ini
+++ b/templates/carbon-relay-ng.ini
@@ -38,8 +38,8 @@ amqp_enabled = false
  key = 'carbon-clickhouse'
  type = 'consistentHashing'
  destinations = [
-   "${GRAFANA_NET_ADDR}:2103",
-   "${GRAFANA_NET_API_KEY}:2103"
+   "${GRAFANA_NET_ADDR}",
+   "${GRAFANA_NET_API_KEY}"
  ]
 
 [instrumentation]


### PR DESCRIPTION
What did we do?
--

1. add port 2103 to GRAFANA_NET_ADDR
2. add port 2103 GRAFANA_NET_API_KEY

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4120

Evidence of work
--

1.

Next Steps
--

1.

Risks
--

1.

Collaboration
--

Co-authored-by: Stephen Palfreyman <18111914+sjpalf@users.noreply.github.com>
