### PR TITLE
TEL-4120 rewrite internal metrics for carbon-relay-ng

### DIFF
--- a/templates/carbon-relay-ng.ini
+++ b/templates/carbon-relay-ng.ini
@@ -48,8 +48,14 @@ graphite_interval = 6000  # in ms
 
 # Rewrite carbon-relay-ng internal metrics
 [[rewriter]]
-old = '^carbon-relay-ng\.([^.]+)\.(graphite-relay|clickhouse-server-shard_[0-9])-ip-([^.]+)\.(.*)'
-new = 'telemetry.metrics.carbon-relay-ng.$2.$3.$1.$4'
+old = '^carbon-relay-ng\.([^.]+)\.ip-([^.]+)\.(.*)'
+new = 'telemetry.metrics.carbon-relay-ng.ecs-carbon-relay.$2.$1.$3'
+max = -1
+
+# alter carbon-relay-ng metrics for relay nodes
+[[rewriter]]
+old = 'service_is_carbon-relay-ng.instance_is_ip-'
+new = 'telemetry.metrics.carbon-relay-ng.ecs-carbon-relay.'
 max = -1
 
 # Rename PostgreSQL metrics

--- a/templates/carbon-relay-ng.ini
+++ b/templates/carbon-relay-ng.ini
@@ -52,45 +52,43 @@ old = '^carbon-relay-ng\.([^.]+)\.(graphite-relay|clickhouse-server-shard_[0-9])
 new = 'telemetry.metrics.carbon-relay-ng.$2.$3.$1.$4'
 max = -1
 
-# Rename postgresql metrics
+# Rename PostgreSQL metrics
 [[rewriter]]
 old = '^collectd\.([^\.]+)\.postgresql-(.*)'
 new = 'rds.postgresql.$1.$2'
 max = -1
 
-# fix container hostnames for heritage (private zone\CIP)
+# Fix container hostnames for heritage (private zone\CIP)
 [[rewriter]]
 old = '(play|portal)\.([\w|-]*)\.+([-\d]+)\.(.*)'
 new = '$1.$2.$3-$4'
 max = -1
 
-# fix container hostnames for ECS (MDTP)
+# Fix container hostnames for ECS (MDTP)
 [[rewriter]]
 old = '(play|portal)\.([\w|-]*)\.+ip-([^\.]+)\.eu-west-2\.compute\.internal\.(.*)'
 new = '$1.$2.ecs-$3-$2.$4'
 max = -1
 
-# rewrite ingress-gateway metrics
-# from: 'telegraf.<EC2-instanceId>.<metric-type>.envoy.ingressgateway-<ZONE_AND_SUFFIX>.<ecs-task-id>.<metric-path>[.<metric-path>]*'
-# to: 'microservice.<microservice-name-and-zone>.<ecs-task-id>.<envoy>.<metric_type>.<metric-path>[.<metric-path>]*'
+# Rewrite ingress-gateway metrics
 [[rewriter]]
 old = '^telegraf\.(?:[^\.]+)\.([^\.]+)\.envoy\.ingressgateway-(public-rate|public-monolith|protected-rate|mdtp|public|protected)[^\.]*\.([^\.]+)\.(.*)+'
 new = 'microservice.ingressgateway-$2.$3.envoy.$1.$4'
 max = -1
 
-# rewrite envoy metrics
-# from: 'telegraf.<EC2-instanceId>.<metric-type>.envoy.<SERVICE_NAME_AND_ZONE>.<ecs-task-id>.<metric-path>[.<metric-path>]*'
-# to: 'microservice.<microservice-name>.<ecs-task-id>.<envoy>.<metric_type>.<metric-path>[.<metric-path>]*'
+# Rewrite envoy metrics
 [[rewriter]]
 old = '^telegraf\.(?:[^\.]+)\.([^\.]+)\.envoy\.([^\.]+)-(?:public-rate|public-monolith|protected-rate|mdtp|public|protected)[^\.]*\.([^\.]+)\.(.*)+'
 new = 'microservice.$2.$3.envoy.$1.$4'
 max = -1
 
+# Rewrite fluentbit forwarder metrics
+[[rewriter]]
+old = '^telegraf\.([^\.]+)\.([^\.]+)\.prometheus\.([^\.]+)\.[^\.]+fluentbit-forwarder[^\.]+\.prometheus\.(.*)'
+new = 'logging.$2.$1.$3.$4'
+max = -1
 
-# rewrite telegraf/ecs-agent/fluentbit-forwarder docker input metrics.
-# These are the metrics from the docker input plugin prefixed with docker-insights
-# from: 'docker-insights.<EC2-instanceId>.<ECS_CLUSTER_TAG>.<TELEGRAF_TAG>.<container_image>.<container_name>.<container_status>.<container_version>.<metric-path>'
-# to: 'telemetry.metrics.ecs.<cluster-name>.<EC2-instanceId>.<container_name>.<metric-path>'
+# Rewrite telegraf/ecs-agent/fluentbit-forwarder docker input metrics.
 [[rewriter]]
 old = '^docker-insights\.([^\.]+)\.([^\.]+)\.([^\.]+)\.([^\.]+)\.([^\.]+)\.([^\.]+)\.([^\.]+)\.(.*)'
 new = 'telemetry.metrics.ecs.$2.$1.$5.$8'

--- a/templates/carbon-relay-ng.ini
+++ b/templates/carbon-relay-ng.ini
@@ -71,24 +71,33 @@ new = '$1.$2.ecs-$3-$2.$4'
 max = -1
 
 # Rewrite ingress-gateway metrics
+# from: 'telegraf.<EC2-instanceId>.<metric-type>.envoy.ingressgateway-<ZONE_AND_SUFFIX>.<ecs-task-id>.<metric-path>[.<metric-path>]*'
+# to: 'microservice.<microservice-name-and-zone>.<ecs-task-id>.<envoy>.<metric_type>.<metric-path>[.<metric-path>]*'
 [[rewriter]]
 old = '^telegraf\.(?:[^\.]+)\.([^\.]+)\.envoy\.ingressgateway-(public-rate|public-monolith|protected-rate|mdtp|public|protected)[^\.]*\.([^\.]+)\.(.*)+'
 new = 'microservice.ingressgateway-$2.$3.envoy.$1.$4'
 max = -1
 
 # Rewrite envoy metrics
+# from: 'telegraf.<EC2-instanceId>.<metric-type>.envoy.<SERVICE_NAME_AND_ZONE>.<ecs-task-id>.<metric-path>[.<metric-path>]*'
+# to: 'microservice.<microservice-name>.<ecs-task-id>.<envoy>.<metric_type>.<metric-path>[.<metric-path>]*'
 [[rewriter]]
 old = '^telegraf\.(?:[^\.]+)\.([^\.]+)\.envoy\.([^\.]+)-(?:public-rate|public-monolith|protected-rate|mdtp|public|protected)[^\.]*\.([^\.]+)\.(.*)+'
 new = 'microservice.$2.$3.envoy.$1.$4'
 max = -1
 
 # Rewrite fluentbit forwarder metrics
+# from: 'telegraf.<EC2-instanceId>.<cluster-name>.<input_tag>.<output_plugin>.<api_endpoint>.<input_tag>.<metric-path>'
+# to: 'logging.<cluster-name>.<EC2-instanceId>.<output_plugin>.<metric-path>'
 [[rewriter]]
 old = '^telegraf\.([^\.]+)\.([^\.]+)\.prometheus\.([^\.]+)\.[^\.]+fluentbit-forwarder[^\.]+\.prometheus\.(.*)'
 new = 'logging.$2.$1.$3.$4'
 max = -1
 
 # Rewrite telegraf/ecs-agent/fluentbit-forwarder docker input metrics.
+# These are the metrics from the docker input plugin prefixed with docker-insights
+# from: 'docker-insights.<EC2-instanceId>.<ECS_CLUSTER_TAG>.<TELEGRAF_TAG>.<container_image>.<container_name>.<container_status>.<container_version>.<metric-path>'
+# to: 'telemetry.metrics.ecs.<cluster-name>.<EC2-instanceId>.<container_name>.<metric-path>'
 [[rewriter]]
 old = '^docker-insights\.([^\.]+)\.([^\.]+)\.([^\.]+)\.([^\.]+)\.([^\.]+)\.([^\.]+)\.([^\.]+)\.(.*)'
 new = 'telemetry.metrics.ecs.$2.$1.$5.$8'

--- a/templates/carbon-relay-ng.ini
+++ b/templates/carbon-relay-ng.ini
@@ -48,59 +48,52 @@ graphite_interval = 6000  # in ms
 
 # Rewrite carbon-relay-ng internal metrics
 [[rewriter]]
-old = '/^carbon-relay-ng\.([^.]+)\.(graphite-relay|clickhouse-server-shard_[0-9])-ip-([^.]+)\.(.*)/'
-new = 'telemetry.metrics.carbon-relay-ng.${2}.${3}.${1}.${4}'
+old = '^carbon-relay-ng\.([^.]+)\.(graphite-relay|clickhouse-server-shard_[0-9])-ip-([^.]+)\.(.*)'
+new = 'telemetry.metrics.carbon-relay-ng.$2.$3.$1.$4'
 max = -1
 
 # Rename postgresql metrics
 [[rewriter]]
-old = '/^collectd\.([^\.]+)\.postgresql-(.*)/'
-new = 'rds.postgresql.${1}.${2}'
+old = '^collectd\.([^\.]+)\.postgresql-(.*)'
+new = 'rds.postgresql.$1.$2'
 max = -1
 
 # fix container hostnames for heritage (private zone\CIP)
 [[rewriter]]
-old = '/(play|portal)\.([\w|-]*)\.+([-\d]+)\.(.*)/'
-new = '${1}.${2}.${3}-${4}'
+old = '(play|portal)\.([\w|-]*)\.+([-\d]+)\.(.*)'
+new = '$1.$2.$3-$4'
 max = -1
 
 # fix container hostnames for ECS (MDTP)
 [[rewriter]]
-old = '/(play|portal)\.([\w|-]*)\.+ip-([^\.]+)\.eu-west-2\.compute\.internal\.(.*)/'
-new = '${1}.${2}.ecs-${3}-${2}.${4}'
+old = '(play|portal)\.([\w|-]*)\.+ip-([^\.]+)\.eu-west-2\.compute\.internal\.(.*)'
+new = '$1.$2.ecs-$3-$2.$4'
 max = -1
 
 # rewrite ingress-gateway metrics
 # from: 'telegraf.<EC2-instanceId>.<metric-type>.envoy.ingressgateway-<ZONE_AND_SUFFIX>.<ecs-task-id>.<metric-path>[.<metric-path>]*'
 # to: 'microservice.<microservice-name-and-zone>.<ecs-task-id>.<envoy>.<metric_type>.<metric-path>[.<metric-path>]*'
 [[rewriter]]
-old = '/^telegraf\.(?:[^\.]+)\.([^\.]+)\.envoy\.ingressgateway-(public-rate|public-monolith|protected-rate|mdtp|public|protected)[^\.]*\.([^\.]+)\.(.*)+/'
-new = 'microservice.ingressgateway-${2}.${3}.envoy.${1}.${4}'
+old = '^telegraf\.(?:[^\.]+)\.([^\.]+)\.envoy\.ingressgateway-(public-rate|public-monolith|protected-rate|mdtp|public|protected)[^\.]*\.([^\.]+)\.(.*)+'
+new = 'microservice.ingressgateway-$2.$3.envoy.$1.$4'
 max = -1
 
 # rewrite envoy metrics
 # from: 'telegraf.<EC2-instanceId>.<metric-type>.envoy.<SERVICE_NAME_AND_ZONE>.<ecs-task-id>.<metric-path>[.<metric-path>]*'
 # to: 'microservice.<microservice-name>.<ecs-task-id>.<envoy>.<metric_type>.<metric-path>[.<metric-path>]*'
 [[rewriter]]
-old = '/^telegraf\.(?:[^\.]+)\.([^\.]+)\.envoy\.([^\.]+)-(?:public-rate|public-monolith|protected-rate|mdtp|public|protected)[^\.]*\.([^\.]+)\.(.*)+/'
-new = 'microservice.${2}.${3}.envoy.${1}.${4}'
+old = '^telegraf\.(?:[^\.]+)\.([^\.]+)\.envoy\.([^\.]+)-(?:public-rate|public-monolith|protected-rate|mdtp|public|protected)[^\.]*\.([^\.]+)\.(.*)+'
+new = 'microservice.$2.$3.envoy.$1.$4'
 max = -1
 
-# rewrite fluentbit forwarder metrics
-# from: 'telegraf.<EC2-instanceId>.<cluster-name>.<input_tag>.<output_plugin>.<api_endpoint>.<input_tag>.<metric-path>'
-# to: 'logging.<cluster-name>.<EC2-instanceId>.<output_plugin>.<metric-path>'
-[[rewriter]]
-old = '/^telegraf\.([^\.]+)\.([^\.]+)\.prometheus\.([^\.]+)\.[^\.]+fluentbit-forwarder[^\.]+\.prometheus\.(.*)/'
-new = 'logging.${2}.${1}.${3}.${4}'
-max = -1
 
 # rewrite telegraf/ecs-agent/fluentbit-forwarder docker input metrics.
 # These are the metrics from the docker input plugin prefixed with docker-insights
 # from: 'docker-insights.<EC2-instanceId>.<ECS_CLUSTER_TAG>.<TELEGRAF_TAG>.<container_image>.<container_name>.<container_status>.<container_version>.<metric-path>'
 # to: 'telemetry.metrics.ecs.<cluster-name>.<EC2-instanceId>.<container_name>.<metric-path>'
 [[rewriter]]
-old = '/^docker-insights\.([^\.]+)\.([^\.]+)\.([^\.]+)\.([^\.]+)\.([^\.]+)\.([^\.]+)\.([^\.]+)\.(.*)/'
-new = 'telemetry.metrics.ecs.${2}.${1}.${5}.${8}'
+old = '^docker-insights\.([^\.]+)\.([^\.]+)\.([^\.]+)\.([^\.]+)\.([^\.]+)\.([^\.]+)\.([^\.]+)\.(.*)'
+new = 'telemetry.metrics.ecs.$2.$1.$5.$8'
 max = -1
 
 # Max aggregation on ActiveMQ queue size


### PR DESCRIPTION
What did we do?
--

1. remove syntax that doesn't align with carbon-relay-ng convention

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4120

Evidence of work
--

1.

Next Steps
--

1. observe if this fixes the issues to accessing metrics 


Collaboration
--

Co-authored-by: Stephen Palfreyman <18111914+sjpalf@users.noreply.github.com>
