### PR TITLE
TEL-4120 set spool metrics to true

### DIFF
--- a/templates/carbon-relay-ng.ini
+++ b/templates/carbon-relay-ng.ini
@@ -38,8 +38,8 @@ amqp_enabled = false
  key = 'carbon-clickhouse'
  type = 'consistentHashing'
  destinations = [
-   "${GRAFANA_NET_ADDR}",
-   "${GRAFANA_NET_API_KEY}"
+   '${GRAFANA_NET_ADDR} spool=true',
+   '${GRAFANA_NET_API_KEY} spool=true'
  ]
 
 [instrumentation]


### PR DESCRIPTION
What did we do?
--

1. enabled spool metrics for carbon-relay-ng

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4120

Evidence of work
![image](https://github.com/hmrc/telemetry-carbon-relay-ng/assets/66684341/6d085017-b0cb-4cee-b36c-2888f778ece3)

Next Steps
--

1.

Risks
--

1.

Collaboration
--

Co-authored-by: Stephen Palfreyman <18111914+sjpalf@users.noreply.github.com>
