### PR TITLE
TEL-4528 Include CIP zone

### DIFF
--- a/templates/carbon-relay-ng.ini
+++ b/templates/carbon-relay-ng.ini
@@ -88,7 +88,7 @@ max = -1
 # from: 'telegraf.<EC2-instanceId>.<metric-type>.envoy.<SERVICE_NAME_AND_ZONE>.<ecs-task-id>.<metric-path>[.<metric-path>]*'
 # to: 'microservice.<microservice-name>.<ecs-task-id>.<envoy>.<metric_type>.<metric-path>[.<metric-path>]*'
 [[rewriter]]
-old = '/^telegraf\.(?:[^\.]+)\.([^\.]+)\.envoy\.([^\.]+)-(?:public-rate|public-monolith|protected-rate|mdtp|public|protected)[^\.]*\.([^\.]+)\.(.*)+/'
+old = '/^telegraf\.(?:[^\.]+)\.([^\.]+)\.envoy\.([^\.]+)-(?:public-rate|public-monolith|protected-rate|mdtp|public|protected|cip)[^\.]*\.([^\.]+)\.(.*)+/'
 new = 'microservice.$2.$3.envoy.$1.$4'
 max = -1
 


### PR DESCRIPTION
What did we do?
--

1. Include CIP zone
This is only to address the envoy metrics rewrite for CIP service-zone and will not cover [other CIP rewrites added to the AMI's configuration](https://github.com/hmrc/aws-ami-graphite-relay/blob/33d9c968315a76dd256f670524ce75aa1a9c9e8b/files/carbon-relay-ng/carbon-relay-ng.conf.tpl#L126-L191).

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4528

Evidence of work
--

1.

Next Steps
--

1.

Risks
--

1.

Collaboration
--

Co-authored-by:
