### PR TITLE
TEL-4422 Backports upstream changes to carbon relay configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Test 3: Successful Scenario
   3. In the ClickHouse interactive mode, run the following SQL query to check if the ClickHouse container is working:``` SELECT * FROM graphite.graphite ORDER BY Date DESC  LIMIT 5 ```
   4. Ensure that you see relevant data.
   5. Send a metric to the Carbon ClickHouse setup: ```echo "test.test 5 `date +%s`" | nc -w0 localhost 2003```
-  5. Confirm that the metrics you sent are reflected in the ClickHouse database: ```SELECT * FROM graphite.graphite where Path = 'test.test' ORDER BY Date DESC  LIMIT 5```
+  6. Confirm that the metrics you sent are reflected in the ClickHouse database: ```SELECT * FROM graphite.graphite where Path = 'test.test' ORDER BY Date DESC  LIMIT 5```
 
 ### Stop and Remove the Docker Containers:
 ```docker-compose down```

--- a/templates/carbon-relay-ng.ini
+++ b/templates/carbon-relay-ng.ini
@@ -108,6 +108,72 @@ max = -1
 old = '/^docker-insights\.([^\.]+)\.([^\.]+)\.([^\.]+)\.([^\.]+)\.([^\.]+)\.([^\.]+)\.([^\.]+)\.(.*)/'
 new = 'telemetry.metrics.ecs.$2.$1.$5.$8'
 max = -1
+# Rewrite CIP PaaS Ingress Services to include '-blue' suffix in the service name
+# These are the metrics from the CIP PaaS telegraf sidecar containers which export metrics for all containers within the task
+# from: 'telegraf.<EC2-instanceId>.<cluster_arn>.<cluster_arn>.<service_name>.<container_id>.<container_name>.<task_revision>.<task_arn>.<metric_path>'
+# to:   'telegraf.<EC2-instanceId>.<cluster_arn>.<cluster_arn>.<service_name>-blue.<container_id>.<container_name>.<task_revision>.<task_arn>.<metric_path>'
+# example
+# from: 'telegraf.ip-10-64-28-152_eu-west-2_compute_internal.arn:aws:ecs:eu-west-2:893166705434:cluster-paas-3094.arn:aws:ecs:eu-west-2:893166705434:cluster-paas-3094.envoy.mdtp-paas-ingress-3094.687b8171da1349069b1f94e69da30153-4057181352.envoy.1.arn:aws:ecs:eu-west-2:893166705434:task-paas-3094-687b8171da1349069b1f94e69da30153.ecs_container_mem.usage_percent'
+# to: 'telegraf.ip-10-64-28-152_eu-west-2_compute_internal.arn:aws:ecs:eu-west-2:893166705434:cluster-paas-3094.arn:aws:ecs:eu-west-2:893166705434:cluster-paas-3094.envoy.mdtp-paas-ingress-3094-blue.687b8171da1349069b1f94e69da30153-4057181352.envoy.1.arn:aws:ecs:eu-west-2:893166705434:task-paas-3094-687b8171da1349069b1f94e69da30153.ecs_container_mem.usage_percent'
+[[rewriter]]
+old = '/(^telegraf\.[^\.]+\.arn:aws:ecs:[^\.]+:[^\.]+:cluster-paas[^\.]*\..*paas-ingress[^\.]*)(\..*)/'
+new = '${1}-blue${2}'
+max = -1
+
+# rewrite CIP PaaS telegraf ecs plugin container memory metrics
+# from: 'telegraf.<EC2-instanceId>.<cluster_arn>.<cluster_arn>.<container_name>.<service_name>-<deployment_colour>.<container_id>.<container_name>.<task_revision>.<task_arn>.ecs_container_meta|ecs_container_mem.<metric_path>'
+# to:   'cip.metrics.ecs.<cluster_name>.<service_name>.<deployment_colour>.<task_id>.<container_name>.ecs_container_meta|ecs_container_mem.<metric_path>'
+# example
+# from: 'telegraf.ip-10-64-28-152_eu-west-2_compute_internal.arn:aws:ecs:eu-west-2:893166705434:cluster-paas-3094.arn:aws:ecs:eu-west-2:893166705434:cluster-paas-3094.fluentbit.cip-hello-flask-3094-blue.687b8171da1349069b1f94e69da30153-3040842310.fluentbit.1.arn:aws:ecs:eu-west-2:893166705434:task-paas-3094-687b8171da1349069b1f94e69da30153.ecs_container_mem.hierarchical_memory_limit'
+# to: 'cip.metrics.ecs.paas-3094.cip-hello-flask-3094.blue.687b8171da1349069b1f94e69da30153.fluentbit.ecs_container_mem.hierarchical_memory_limit'
+[[rewriter]]
+old = '/^telegraf\.[^\.]+\.arn:aws:ecs:[^\.]+:[^\.]+:cluster-(paas[^\.]*)\.arn:aws:ecs:[^\.]+\.([^\.]+)\.([^\.]+)-([^\.]+)\.([^\.]+)\-[^\.]+\..*\.(ecs_container_meta|ecs_container_mem)\.(.*)/'
+new = 'cip.metrics.ecs.${1}.${3}.${4}.${5}.${2}.${6}.${7}'
+max = -1
+
+# rewrite CIP PaaS telegraf ecs plugin container cpu metrics
+# from: 'telegraf.<EC2-instanceId>.<cluster_arn>.<cluster_arn>.<container_name>.cpu*.<service_name>-<deployment_colour>.<container_id>.<container_name>.<task_revision>.<task_arn>.ecs_container_cpu.<metric_path>'
+# to:   'cip.metrics.ecs.<cluster_name>.<service_name>.<deployment_colour>.<task_id>.<container_name>.ecs_container_cpu.cpu*.<metric_path>'
+# example
+# from: 'telegraf.ip-10-64-28-152_eu-west-2_compute_internal.arn:aws:ecs:eu-west-2:893166705434:cluster-paas-3094.arn:aws:ecs:eu-west-2:893166705434:cluster-paas-3094.fluentbit.cpu-total.cip-hello-flask-3094-blue.687b8171da1349069b1f94e69da30153-3040842310.fluentbit.1.arn:aws:ecs:eu-west-2:893166705434:task-paas-3094-687b8171da1349069b1f94e69da30153.ecs_container_cpu.usage_total'
+# to: 'cip.metrics.ecs.paas-3094.cip-hello-flask-3094.blue.687b8171da1349069b1f94e69da30153.fluentbit.ecs_container_cpu.cpu-total.usage_total'
+[[rewriter]]
+old = '/^telegraf\.[^\.]+\.arn:aws:ecs:[^\.]+:[^\.]+:cluster-(paas[^\.]*)\.arn:aws:ecs:[^\.]+\.[^\.]+\.(cpu[^\.]*)\.([^\.]+)-([^\.]+)\.([^\.]+)-[^\.]+\.([^\.]+)\.[^\.]+\.[^\.]+\.(ecs_container_cpu)\.(.*)/'
+new = 'cip.metrics.ecs.${1}.${3}.${4}.${5}.${6}.${7}.${2}.${8}'
+max = -1
+
+# rewrite CIP PaaS telegraf ecs plugin container network metrics
+# from: 'telegraf.<EC2-instanceId>.<cluster_arn>.<cluster_arn>.<container_name>.<service_name>-<deployment_colour>.<container_id>.<container_name>.<task_revision>.<task_arn>.ecs_container_net.<metric_path>'
+# to:   'cip.metrics.ecs.<cluster_name>.<service_name>.<deployment_colour>.<task_id>.<container_name>.ecs_container_net.<metric_path>'
+# example
+# from: 'telegraf.ip-10-64-28-152_eu-west-2_compute_internal.arn:aws:ecs:eu-west-2:893166705434:cluster-paas-3094.arn:aws:ecs:eu-west-2:893166705434:cluster-paas-3094.envoy.cip-hello-flask-3094-blue.687b8171da1349069b1f94e69da30153-4057181352.envoy.total.1.arn:aws:ecs:eu-west-2:893166705434:task-paas-3094-687b8171da1349069b1f94e69da30153.ecs_container_net.tx_bytes'
+# to: 'cip.metrics.ecs.paas-3094.cip-hello-flask-3094.blue.687b8171da1349069b1f94e69da30153.envoy.ecs_container_net.total.tx_bytes'
+[[rewriter]]
+old = '/^telegraf\.[^\.]+\.arn:aws:ecs:[^\.]+:[^\.]+:cluster-(paas[^\.]*)\.arn:aws:ecs:[^\.]+\.([^\.]+)\.([^\.]+)-([^\.]+)\.([^\.]+)\-[^\.]+\.[^\.]+\.([^\.]+)\..*\.(ecs_container_net)\.(.*)/'
+new = 'cip.metrics.ecs.${1}.${3}.${4}.${5}.${2}.${7}.${6}.${8}'
+max = -1
+
+# rewrite CIP PaaS telegraf ecs plugin container blkio metrics
+# from: 'telegraf.<EC2-instanceId>.<cluster_arn>.<cluster_arn>.<container_name>.<device>.<service_name>-<deployment_colour>.<container_id>.<container_name>.<task_revision>.<task_arn>.ecs_container_blkio.<metric_path>'
+# to:   'cip.metrics.ecs.<cluster_name>.<service_name>.<deployment_colour>.<task_id>.<container_name>.ecs_container_blkio.<device>.<metric_path>'
+# example
+# from: 'telegraf.ip-10-64-28-152_eu-west-2_compute_internal.arn:aws:ecs:eu-west-2:893166705434:cluster-paas-3094.arn:aws:ecs:eu-west-2:893166705434:cluster-paas-3094.envoy.259:0.cip-hello-flask-3094-blue.687b8171da1349069b1f94e69da30153-4057181352.envoy.1.arn:aws:ecs:eu-west-2:893166705434:task-paas-3094-687b8171da1349069b1f94e69da30153.ecs_container_blkio.io_service_bytes_recursive_sync'
+# to: 'cip.metrics.ecs.paas-3094.cip-hello-flask-3094.blue.687b8171da1349069b1f94e69da30153.envoy.ecs_container_blkio.259:0.io_service_bytes_recursive_sync'
+[[rewriter]]
+old = '/^telegraf\.[^\.]+\.arn:aws:ecs:[^\.]+:[^\.]+:cluster-(paas[^\.]*)\.arn:aws:ecs:[^\.]+\.([^\.]+)\.([^\.]+)\.([^\.]+)-([^\.]+)\.([^\.]+)-[^\.]+\..*\.(ecs_container_blkio)\.(.*)/'
+new = 'cip.metrics.ecs.${1}.${4}.${5}.${6}.${2}.${7}.${3}.${8}'
+max = -1
+
+# rewrite CIP PaaS telegraf ecs plugin task metrics
+# from: 'telegraf.<EC2-instanceId>.<cluster_arn>.<service_name>-<deployment_colour>.<task_revision>.<task_arn>.ecs_task.<metric_path>'
+# to:   'cip.metrics.ecs.<cluster_name>.<service_name>.<deployment_colour>.<task_id>.ecs_task.<metric_path>'
+# example
+# from: 'telegraf.ip-10-64-28-152_eu-west-2_compute_internal.arn:aws:ecs:eu-west-2:893166705434:cluster-paas-3094.cip-hello-flask-3094-blue.1.arn:aws:ecs:eu-west-2:893166705434:task-paas-3094-687b8171da1349069b1f94e69da30153.ecs_task.limit_cpu'
+# to: 'cip.metrics.ecs.paas-3094.cip-hello-flask-3094.blue.687b8171da1349069b1f94e69da30153.ecs_task.limit_cpu'
+[[rewriter]]
+old = '/^telegraf\.[^\.]+\.arn:aws:ecs:[^\.]+:[^\.]+:cluster-(paas[^\.]*)\.([^\.]+)-([^\.]+)\.[^\.]+\..*:task-.*-([^\.]*)\.(ecs_task)\.(.*)/'
+new = 'cip.metrics.ecs.${1}.${2}.${3}.${4}.${5}.${6}'
+max = -1
 
 # Max aggregation on ActiveMQ queue size
 [[aggregation]]


### PR DESCRIPTION
References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4422
https://jira.tools.tax.service.gov.uk/browse/CIE-3094 (former ticket these changes are being backported from)

Evidence of work
--

n/a - needs testing

Next Steps
--

build + verify in integration

Risks
--

1. This config exists in aws-ami-graphite-relay and not in the containerised version, is that a problem? Looks like it predates Riz's project and came in in TEL-3845:

<img width="436" alt="image" src="https://github.com/user-attachments/assets/d992e7e5-baf3-4c08-8ef7-5b46566865a6">

2. There is no PR checker that I can find; there is a spec for it but no job configured

Collaboration
--

Co-authored by: Stephen Palfreyman <18111914+sjpalf@users.noreply.github.com>

