### PR TITLE
INFRA-8791: Rewrite Consul metrics to App Mesh paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM ${DOCKERHUB}grafana/carbon-relay-ng
+FROM dockerhub.tax.service.gov.uk/grafana/carbon-relay-ng
 
 COPY templates/carbon-relay-ng.ini /conf/carbon-relay-ng.ini

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 
 # telemetry-carbon-relay-ng
 
+> [!WARNING]
+> The tests in `tests/` are not run automatically and do not cover all functionality
+
 # Running Tests with Docker Compose
 
 Before running the tests, ensure that you have Docker Compose installed and the required containers are built and running.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     command: carbon-clickhouse -config="/carbon-clickhouse.toml"
 
   clickhouse:
-    image: docker.io/bitnami/clickhouse:23
+    image: public.ecr.aws/bitnami/clickhouse:23
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
       - ANOTHER_VARIABLE=value

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     environment:
       - GRAFANA_NET_ADDR=carbon-clickhouse:2103
       - GRAFANA_NET_API_KEY=carbon-clickhouse:2103
+    volumes:
+      -  ${PWD}/templates/carbon-relay-ng.ini:/conf/carbon-relay-ng.ini
 
   carbon-clickhouse:
     image: lomik/carbon-clickhouse:latest
@@ -22,6 +24,7 @@ services:
     command: carbon-clickhouse -config="/carbon-clickhouse.toml"
 
   clickhouse:
+    container_name: clickhouse
     image: public.ecr.aws/bitnami/clickhouse:23
     environment:
       - ALLOW_EMPTY_PASSWORD=yes

--- a/templates/carbon-relay-ng.ini
+++ b/templates/carbon-relay-ng.ini
@@ -46,6 +46,9 @@ amqp_enabled = false
 graphite_addr = "localhost:2003"
 graphite_interval = 6000  # in ms
 
+# regex replacements should be double bracket ${{}} if followed by an underscore
+# because environment variables are attempted to be interpolated stripping the outer brackets
+
 # Rewrite carbon-relay-ng internal metrics
 [[rewriter]]
 old = '/^carbon-relay-ng\.([^.]+)\.ip-([^.]+)\.(.*)/'
@@ -76,20 +79,44 @@ old = '/(play|portal)\.([\w|-]*)\.+ip-([^\.]+)\.eu-west-2\.compute\.internal\.(.
 new = '$1.$2.ecs-$3-$2.$4'
 max = -1
 
-# Rewrite ingress-gateway metrics
+# Rewrite Consul API gateway app-mesh-compat metrics to use App Mesh cluster names
+[[rewriter]]
+old = '/^telegraf\.(?<host>[^\.]+)\.(?<metric_type>[^\.]+)\.app-mesh-compat\.envoy.consul-apigw\.(?<datacenter>[^\.]+)\.(?<zone>[^\.]+)\.(?<task_id>[^\.]+)\.cluster\.(?<service_name>[^\.]+)\.(?<namespace>default)\.(?<datacenter_again>[^\.]+)\.internal\.(?<trust_domain>[^\.]+\.consul)\.(?<metric_path>.*)/'
+new = 'telegraf.${{host}}.${{metric_type}}.app-mesh-compat.envoy.consul-apigw.${{datacenter}}.${{zone}}.${{task_id}}.cluster.cds_egress_mdtp-app-mesh_${{service_name}}-${{zone}}_http_8080.${{metric_path}}'
+max = -1
+
+# Rewrite Consul microservice app-mesh-compat metrics to use App Mesh cluster names
+[[rewriter]]
+old = '/^telegraf\.(?<host>[^\.]+)\.(?<metric_type>[^\.]+)\.app-mesh-compat\.envoy\.(?<service_name_and_zone>[^\.]+)\.(?<task_id>[^\.]+)\.cluster.local_app.(?<metric_path>.*)/'
+new = 'telegraf.${{host}}.${{metric_type}}.envoy.${{service_name_and_zone}}.consul-${{task_id}}.cluster.cluster_ingress_http_8080.${{metric_path}}'
+max = -1
+
+# Rewrite Consul API gateway app-mesh-compat metrics to impersonate ingress-gateways
+[[rewriter]]
+old = '/^telegraf\.(?<host>[^\.]+)\.(?<metric_type>[^\.]+)\.app-mesh-compat\.envoy\.consul-apigw\.(?<datacenter>[^\.]+)\.(?<zone>[^\.]+)\.(?<task_id>[^\.]+)\.(?<metric_path>.*)/'
+new = 'telegraf.${{host}}.${{metric_type}}.envoy.ingressgateway-${{zone}}.consul-${{task_id}}.${{metric_path}}'
+max = -1
+
+# Rewrite Consul API gateway metrics, preserving zone
+[[rewriter]]
+old = '/^telegraf\.(?<host>[^\.]+)\.(?<metric_type>[^\.]+)\.envoy\.consul-apigw\.(?<datacenter>[^\.]+)\.(?<zone>[^\.]+)\.(?<task_id>[^\.]+)\.(?<metric_path>.*)/'
+new = 'microservice.consul-apigw-${{datacenter}}-${{zone}}.${{task_id}}.envoy.${{metric_type}}.${{metric_path}}'
+max = -1
+
+# Rewrite ingress-gateway metrics, preserving zone, removing shard
 # from: 'telegraf.<EC2-instanceId>.<metric-type>.envoy.ingressgateway-<ZONE_AND_SUFFIX>.<ecs-task-id>.<metric-path>[.<metric-path>]*'
 # to: 'microservice.<microservice-name-and-zone>.<ecs-task-id>.<envoy>.<metric_type>.<metric-path>[.<metric-path>]*'
 [[rewriter]]
-old = '/^telegraf\.(?:[^\.]+)\.([^\.]+)\.envoy\.ingressgateway-(public-rate|public-monolith|protected-rate|mdtp|public|protected)[^\.]*\.([^\.]+)\.(.*)+/'
-new = 'microservice.ingressgateway-$2.$3.envoy.$1.$4'
+old = '/^telegraf\.(?<host>[^\.]+)\.(?<metric_type>[^\.]+)\.envoy\.ingressgateway-(?<zone>public-rate|public-monolith|protected-rate|mdtp|public|protected)(?<shard>[^\.]*)\.(?<task_id>[^\.]+)\.(?<metric_path>.*)/'
+new = 'microservice.ingressgateway-${{zone}}.${{task_id}}.envoy.${{metric_type}}.${{metric_path}}'
 max = -1
 
-# Rewrite envoy metrics
+# Rewrite service envoy metrics, removing zone
 # from: 'telegraf.<EC2-instanceId>.<metric-type>.envoy.<SERVICE_NAME_AND_ZONE>.<ecs-task-id>.<metric-path>[.<metric-path>]*'
 # to: 'microservice.<microservice-name>.<ecs-task-id>.<envoy>.<metric_type>.<metric-path>[.<metric-path>]*'
 [[rewriter]]
-old = '/^telegraf\.(?:[^\.]+)\.([^\.]+)\.envoy\.([^\.]+)-(?:public-rate|public-monolith|protected-rate|mdtp|public|protected|cip)[^\.]*\.([^\.]+)\.(.*)+/'
-new = 'microservice.$2.$3.envoy.$1.$4'
+old = '/^telegraf\.(?<host>[^\.]+)\.(?<metric_type>[^\.]+)\.envoy\.(?<service_name>[^\.]+)-(?<zone>public-rate|public-monolith|protected-rate|mdtp|public|protected|cip)[^\.]*\.(?<task_id>[^\.]+)\.(?<metric_path>.*)/'
+new = 'microservice.${{service_name}}.${{task_id}}.envoy.${{metric_type}}.${{metric_path}}'
 max = -1
 
 # Rewrite fluentbit forwarder metrics

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,13 @@
+# Envoy rewrite tests
+
+These tests verify the behaviour of the Envoy rewrite rules in `templates/carbon-relay-ng.ini` using a Docker Compose metrics stack.
+Metrics are pushed to `carbon-relay-ng` and the resulting path is read from `clickhouse`.
+
+To run:
+```
+cd ..
+pip install -r tests/requirements.txt
+docker compose up --detach
+pytest
+docker compose down
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,83 @@
+import datetime
+import socket
+import time
+
+import docker
+import pytest
+
+
+def current_timestamp() -> int:
+    now = datetime.datetime.now()
+    return int(now.timestamp())
+
+
+class MetricHelper:
+    def __init__(
+        self, carbon_relay_ng_host: str = "localhost", carbon_relay_ng_port: int = 2003
+    ) -> None:
+        self.clickhouse_container = self.find_clickhouse_container()
+
+        self.carbon_relay_ng_host = carbon_relay_ng_host
+        self.carbon_relay_ng_port = carbon_relay_ng_port
+
+    def send_metric(
+        self, path: str, value: int | float, timestamp: int = current_timestamp()
+    ) -> None:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.connect((self.carbon_relay_ng_host, self.carbon_relay_ng_port))
+
+        message = f"{path} {value} {timestamp}".encode()
+
+        total_sent = 0
+        while total_sent < len(message):
+            sent = sock.send(message[total_sent:])
+            if sent == 0:
+                raise RuntimeError("Socket connection broken")
+            total_sent = total_sent + sent
+
+        sock.close()
+
+    def find_clickhouse_container(
+        self, container_name: str = "^clickhouse$"
+    ) -> docker.models.containers.Container:
+        docker_client = docker.from_env()
+        containers = docker_client.containers.list(filters={"name": container_name})
+        assert len(containers) > 0, "No ClickHouse containers found"
+        assert len(containers) == 1, "Multiple ClickHouse containers found"
+        return containers[0]
+
+    def exec_query(self, query: str) -> str:
+        exit_code, output = self.clickhouse_container.exec_run(
+            f'clickhouse-client --query "{query}"'
+        )
+        return output.decode()
+
+    def get_metric_path_with_value(
+        self,
+        value: str,
+        retry_delay: float = 0.25,
+        max_retries: int = 20,
+    ) -> str | None:
+        for _ in range(1 + max_retries):
+            output = self.exec_query(
+                f"SELECT Path FROM graphite.graphite WHERE Value = {value}"
+            )
+
+            if output != "":
+                return output.strip()
+
+            time.sleep(retry_delay)
+
+        return None
+
+    def delete_metrics_with_value(self, value: str):
+        self.exec_query(f"DELETE FROM graphite.graphite WHERE Value = {value}")
+        assert (
+            self.exec_query(f"SELECT Path FROM graphite.graphite WHERE Value = {value}")
+            == ""
+        )
+
+
+@pytest.fixture(scope="session")
+def metric_helper():
+    return MetricHelper()

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,2 @@
+docker
+pytest

--- a/tests/test_rewrite_envoy.py
+++ b/tests/test_rewrite_envoy.py
@@ -1,0 +1,400 @@
+import dataclasses
+
+import pytest
+
+@dataclasses.dataclass
+class EnvoyTask:
+    instance_id: str
+    task_id: str
+    zone: str
+
+@dataclasses.dataclass
+class MicroserviceTask(EnvoyTask):
+    service_name: str
+
+@dataclasses.dataclass
+class IngressGatewayTask(EnvoyTask):
+    shard: int
+
+@dataclasses.dataclass
+class ConsulAPIGatewayTask(EnvoyTask):
+    datacenter: str
+    consul_uuid: str
+
+
+
+@pytest.mark.parametrize(
+    "ingress_gateway_task, metric_type, metric_path",
+    [
+        (
+            IngressGatewayTask(
+                instance_id="i-9693b71f972105d0f",
+                task_id="944a78e9ba1c2423894a3c0d51e935b5",
+                zone="protected",
+                shard=0,
+            ),
+            "gauge",
+            "cluster.cds_egress_mdtp-app-mesh_platform-status-backend-protected_http_8080.membership_total",
+        ),
+        (
+            IngressGatewayTask(
+                instance_id="i-b77c49bfcf8f3b8aa",
+                task_id="aef738ef6e54b9d23cb072a787f616a4",
+                zone="protected-rate",
+                shard=3,
+            ),
+            "counter",
+            "control_plane.connected_state",
+        ),
+        (
+            IngressGatewayTask(
+                instance_id="i-3e135ef4cbe766e37",
+                task_id="22ff9155c7c045f4ff9179b5bb25b24d",
+                zone="public-monolith",
+                shard=1,
+            ),
+            "timing",
+            "http.ingress.downstream_rq_5xx",
+        ),
+    ],
+)
+def test_rewrite_ingressgateway_envoy_metrics(
+    ingress_gateway_task,
+    metric_type,
+    metric_path,
+    metric_helper,
+):
+    value = 1000000001
+
+    original_path = f"telegraf.{ingress_gateway_task.instance_id}.{metric_type}.envoy.ingressgateway-{ingress_gateway_task.zone}-{ingress_gateway_task.shard}.{ingress_gateway_task.task_id}.{metric_path}"
+    expected_path = f"microservice.ingressgateway-{ingress_gateway_task.zone}.{ingress_gateway_task.task_id}.envoy.{metric_type}.{metric_path}"
+
+    metric_helper.delete_metrics_with_value(value)
+    metric_helper.send_metric(original_path, value)
+    assert metric_helper.get_metric_path_with_value(value) == expected_path
+
+
+@pytest.mark.parametrize(
+    "microservice_task, metric_type, metric_path",
+    [
+        (
+            MicroserviceTask(
+                instance_id="i-9693b71f972105d0f",
+                task_id="944a78e9ba1c2423894a3c0d51e935b5",
+                zone="protected",
+                service_name="platform-status-backend",
+            ),
+            "gauge",
+            "cluster_ingress_http_8080.upstream_rq_time.90_percentile",
+        ),
+        (
+            MicroserviceTask(
+                instance_id="i-b77c49bfcf8f3b8aa",
+                task_id="aef738ef6e54b9d23cb072a787f616a4",
+                zone="protected-rate",
+                service_name="back-office-adapter",
+            ),
+            "counter",
+            "cluster_ingress_http_8080.upstream_rq_[2345][0-9][0-9]",
+        ),
+        (
+            MicroserviceTask(
+                instance_id="i-3e135ef4cbe766e37",
+                task_id="22ff9155c7c045f4ff9179b5bb25b24d",
+                zone="public-monolith",
+                service_name="classic-helpdesk-proxy",
+            ),
+            "timing",
+            "cluster_ingress_http_8080.upstream_rq_{400,401,403,404,500,502,503,504}",
+        ),
+    ],
+)
+def test_rewrite_envoy_microservice(
+    microservice_task,
+    metric_type,
+    metric_path,
+    metric_helper,
+):
+    value = 1000000002
+
+    virtual_node_name = f"{microservice_task.service_name}-{microservice_task.zone}"
+
+    original_path = f"telegraf.{microservice_task.instance_id}.{metric_type}.envoy.{virtual_node_name}.{microservice_task.task_id}.{metric_path}"
+    expected_path = (
+        f"microservice.{microservice_task.service_name}.{microservice_task.task_id}.envoy.{metric_type}.{metric_path}"
+    )
+
+    metric_helper.delete_metrics_with_value(value)
+    metric_helper.send_metric(original_path, value)
+    assert metric_helper.get_metric_path_with_value(value) == expected_path
+
+
+@pytest.mark.parametrize(
+    "api_gateway_task, service_name, metric_type, metric_path",
+    [
+        (
+            ConsulAPIGatewayTask(
+                instance_id="i-9693b71f972105d0f",
+                task_id="ac7bdf74f13327b6e352481485f431f8",
+                zone="protected",
+                datacenter="integration",
+                consul_uuid="34267186-43f7-4d2d-9efc-77227297f0a9",
+            ),
+            "platform-status-backend",
+            "gauge",
+            "membership_total",
+        ),
+        (
+            ConsulAPIGatewayTask(
+                instance_id="i-b77c49bfcf8f3b8aa",
+                task_id="c37e1f1599eb99e776655a34af2cbb4e",
+                zone="protected-rate",
+                datacenter="production",
+                consul_uuid="1dc4b725-b32c-4556-ad45-e480acc70ca1",
+            ),
+            "back-office-adapter",
+            "counter",
+            "upstream_rq_retry",
+        ),
+        (
+            ConsulAPIGatewayTask(
+                instance_id="i-3e135ef4cbe766e37",
+                task_id="ceb827fcc79c8848ff539494f0c57eb7",
+                zone="public-monolith",
+                datacenter="staging",
+                consul_uuid="980406b3-f90e-4031-9562-a7a556cf3842",
+            ),
+            "classic-helpdesk-proxy",
+            "timing",
+            "upstream_rq_time",
+        ),
+    ],
+)
+def test_rewrite_envoy_consul_apigw(
+    api_gateway_task,
+    service_name,
+    metric_type,
+    metric_path,
+    metric_helper,
+):
+    value = 1000000003
+
+    original_path = f"telegraf.{api_gateway_task.instance_id}.{metric_type}.envoy.consul-apigw.{api_gateway_task.datacenter}.{api_gateway_task.zone}.{api_gateway_task.task_id}.cluster.{service_name}-{api_gateway_task.zone}.default.{api_gateway_task.datacenter}.internal.{api_gateway_task.consul_uuid}.consul.{metric_path}"
+    expected_path = f"microservice.consul-apigw-{api_gateway_task.datacenter}-{api_gateway_task.zone}.{api_gateway_task.task_id}.envoy.{metric_type}.cluster.{service_name}-{api_gateway_task.zone}.default.{api_gateway_task.datacenter}.internal.{api_gateway_task.consul_uuid}.consul.{metric_path}"
+
+    metric_helper.delete_metrics_with_value(value)
+    metric_helper.send_metric(original_path, value)
+    assert metric_helper.get_metric_path_with_value(value) == expected_path
+
+
+@pytest.mark.parametrize(
+    "api_gateway_task, service_name, metric_type, metric_path",
+    [
+        (
+            ConsulAPIGatewayTask(
+                instance_id="i-9693b71f972105d0f",
+                task_id="ac7bdf74f13327b6e352481485f431f8",
+                zone="protected",
+                datacenter="integration",
+                consul_uuid="34267186-43f7-4d2d-9efc-77227297f0a9",
+            ),
+            "platform-status-backend",
+            "gauge",
+            "membership_total",
+        ),
+        (
+            ConsulAPIGatewayTask(
+                instance_id="i-b77c49bfcf8f3b8aa",
+                task_id="c37e1f1599eb99e776655a34af2cbb4e",
+                zone="protected-rate",
+                datacenter="production",
+                consul_uuid="1dc4b725-b32c-4556-ad45-e480acc70ca1",
+            ),
+            "back-office-adapter",
+            "counter",
+            "upstream_rq_retry",
+        ),
+        (
+            ConsulAPIGatewayTask(
+                instance_id="i-3e135ef4cbe766e37",
+                task_id="ceb827fcc79c8848ff539494f0c57eb7",
+                zone="public-monolith",
+                datacenter="staging",
+                consul_uuid="980406b3-f90e-4031-9562-a7a556cf3842",
+            ),
+            "classic-helpdesk-proxy",
+            "timing",
+            "upstream_rq_time",
+        ),
+        (
+            ConsulAPIGatewayTask(
+                instance_id="i-3a6695138a3b377a1",
+                task_id="6639bc62629822a74d9572cf0b0c4338",
+                zone="public-monolith",
+                datacenter="engineer-environment",
+                consul_uuid="121e9ca8-5a0e-4804-b004-91e1a3f46984",
+            ),
+            "classic-helpdesk-proxy",
+            "timing",
+            "upstream_rq_time",
+        ),
+    ],
+)
+def test_rewrite_envoy_consul_apigw_app_mesh_compatibility_cluster_name(
+    api_gateway_task,
+    service_name,
+    metric_type,
+    metric_path,
+    metric_helper,
+):
+    """
+    Test that Consul API gateway App Mesh compatibility metrics are rewritten with App Mesh cluster names
+    """
+    value = 1000000004
+
+    original_path = f"telegraf.{api_gateway_task.instance_id}.{metric_type}.app-mesh-compat.envoy.consul-apigw.{api_gateway_task.datacenter}.{api_gateway_task.zone}.{api_gateway_task.task_id}.cluster.{service_name}.default.{api_gateway_task.datacenter}.internal.{api_gateway_task.consul_uuid}.consul.{metric_path}"
+    expected_path = f"microservice.ingressgateway-{api_gateway_task.zone}.consul-{api_gateway_task.task_id}.envoy.{metric_type}.cluster.cds_egress_mdtp-app-mesh_{service_name}-{api_gateway_task.zone}_http_8080.{metric_path}"
+
+    metric_helper.delete_metrics_with_value(value)
+    metric_helper.send_metric(original_path, value)
+    assert metric_helper.get_metric_path_with_value(value) == expected_path
+
+
+@pytest.mark.parametrize(
+    "api_gateway_task, metric_type, metric_path",
+    [
+        (
+            ConsulAPIGatewayTask(
+                instance_id="i-9693b71f972105d0f",
+                task_id="ac7bdf74f13327b6e352481485f431f8",
+                zone="protected",
+                datacenter="integration",
+                consul_uuid="34267186-43f7-4d2d-9efc-77227297f0a9",
+            ),
+            "gauge",
+            "http.ingress_upstream_zone-wildcard.downstream_rq_5xx",
+        ),
+        (
+            ConsulAPIGatewayTask(
+                instance_id="i-b77c49bfcf8f3b8aa",
+                task_id="c37e1f1599eb99e776655a34af2cbb4e",
+                zone="protected-rate",
+                datacenter="production",
+                consul_uuid="1dc4b725-b32c-4556-ad45-e480acc70ca1",
+            ),
+            "counter",
+            "http.ingress_upstream_zone-wildcard.downstream_rq_2xx",
+        ),
+        (
+            ConsulAPIGatewayTask(
+                instance_id="i-3e135ef4cbe766e37",
+                task_id="ceb827fcc79c8848ff539494f0c57eb7",
+                zone="public-monolith",
+                datacenter="staging",
+                consul_uuid="980406b3-f90e-4031-9562-a7a556cf3842",
+            ),
+            "timing",
+            "grpc.ads.streams_closed_0",
+        ),
+        (
+            ConsulAPIGatewayTask(
+                instance_id="i-3a6695138a3b377a1",
+                task_id="6639bc62629822a74d9572cf0b0c4338",
+                zone="public-monolith",
+                datacenter="engineer-environment",
+                consul_uuid="121e9ca8-5a0e-4804-b004-91e1a3f46984",
+            ),
+            "timing",
+            "http.ingress_upstream_zone-wildcard.downstream_rq_time.50_percentile",
+        ),
+    ],
+)
+def test_rewrite_envoy_consul_apigw_app_mesh_compatibility_other(
+    api_gateway_task, metric_type, metric_path, metric_helper
+):
+    """
+    Test that Consul API gateway App Mesh compatibility metrics are rewritten to match App Mesh metric paths
+    """
+    value = 1000000005
+
+    original_path = f"telegraf.{api_gateway_task.instance_id}.{metric_type}.app-mesh-compat.envoy.consul-apigw.{api_gateway_task.datacenter}.{api_gateway_task.zone}.{api_gateway_task.task_id}.{metric_path}"
+    expected_path = f"microservice.ingressgateway-{api_gateway_task.zone}.consul-{api_gateway_task.task_id}.envoy.{metric_type}.{metric_path}"
+
+    metric_helper.delete_metrics_with_value(value)
+    metric_helper.send_metric(original_path, value)
+    assert metric_helper.get_metric_path_with_value(value) == expected_path
+
+
+@pytest.mark.parametrize(
+    "microservice_task, metric_type, metric_path",
+    [
+        (
+            MicroserviceTask(
+                instance_id="i-9693b71f972105d0f",
+                task_id="944a78e9ba1c2423894a3c0d51e935b5",
+                zone="protected",
+                service_name="platform-status-backend",
+            ),
+            "gauge",
+            "membership_total",
+        ),
+        (
+            MicroserviceTask(
+                instance_id="i-b77c49bfcf8f3b8aa",
+                task_id="aef738ef6e54b9d23cb072a787f616a4",
+                zone="protected-rate",
+                service_name="back-office-adapter",
+            ),
+            "counter",
+            "upstream_rq_retry",
+        ),
+        (
+            MicroserviceTask(
+                instance_id="i-3e135ef4cbe766e37",
+                task_id="22ff9155c7c045f4ff9179b5bb25b24d",
+                zone="public-monolith",
+                service_name="classic-helpdesk-proxy",
+            ),
+            "timing",
+            "upstream_rq_time",
+        ),
+        (
+            MicroserviceTask(
+                instance_id="i-3e135ef4cbe766e37",
+                task_id="22ff9155c7c045f4ff9179b5bb25b24d",
+                zone="public-monolith",
+                service_name="classic-helpdesk-proxy",
+            ),
+            "timing",
+            "upstream_rq_time",
+        ),
+    ],
+)
+def test_rewrite_envoy_consul_microservice_app_mesh_compatibility_cluster_name(
+    microservice_task,
+    metric_type,
+    metric_path,
+    metric_helper,
+):
+    """
+    Test that microservice App Mesh compatibility metrics are rewritten with App Mesh cluster names
+    """
+    value = 1000000006
+
+    original_path = f"telegraf.{microservice_task.instance_id}.{metric_type}.app-mesh-compat.envoy.{microservice_task.service_name}-{microservice_task.zone}.{microservice_task.task_id}.cluster.local_app.{metric_path}"
+    expected_path = f"microservice.{microservice_task.service_name}.consul-{microservice_task.task_id}.envoy.{metric_type}.cluster.cluster_ingress_http_8080.{metric_path}"
+
+    metric_helper.delete_metrics_with_value(value)
+    metric_helper.send_metric(original_path, value)
+    assert metric_helper.get_metric_path_with_value(value) == expected_path
+
+
+def test_rewrite_cip(metric_helper):
+    value = 1000000007
+
+    original_path = "telegraf.ip-10-64-28-152_eu-west-2_compute_internal.arn:aws:ecs:eu-west-2:893166705434:cluster-paas-3094.arn:aws:ecs:eu-west-2:893166705434:cluster-paas-3094.fluentbit.cip-hello-flask-3094-blue.687b8171da1349069b1f94e69da30153-3040842310.fluentbit.1.arn:aws:ecs:eu-west-2:893166705434:task-paas-3094-687b8171da1349069b1f94e69da30153.ecs_container_mem.hierarchical_memory_limit"
+    expected_path = "cip.metrics.ecs.paas-3094.cip-hello-flask-3094.blue.687b8171da1349069b1f94e69da30153.fluentbit.ecs_container_mem.hierarchical_memory_limit"
+
+    metric_helper.delete_metrics_with_value(value)
+    metric_helper.send_metric(original_path, value)
+    assert metric_helper.get_metric_path_with_value(value) == expected_path


### PR DESCRIPTION
We generate Grafana dashboards for microservices using the metrics
emitted by App Mesh's Envoy sidecars.
We are migrating to Consul which also uses Envoy sidecars that emit
metrics, but the metric paths are slightly different.
We want to be able to keep the existing dashboards while migrating to
Consul and avoid duplicate dashboards if possible.
If we emit a duplicate set of metrics and rewrite them to mimic App Mesh
metric paths our existing dashboards should continue to function.

Rewrite Consul Envoy "compatibility" metrics to resemble App Mesh
metrics.

---------

Rewriting the paths of our Envoy metrics involves multiple chained
regular expressions. It can be difficult to understand exactly how a
metric path is rewritten without testing it.
Additionally, the config format for carbon-relay-ng uses the same syntax
for environment variable interpolation and regex replacements. This can
result in unexpected behaviour.

Add automated tests for Envoy metric rewrite behaviour.

----------

Bitnami ClickHouse images are no longer hosted on Docker Hub but are
available on ECR.

Use ClickHouse image from ECR.